### PR TITLE
Feat/#27 create Challenge api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "express": "^4.21.2",
         "http-status-codes": "^2.3.0",
         "jsonwebtoken": "^9.0.2",
+        "moment": "^2.30.1",
+        "moment-timezone": "^0.5.46",
         "morgan": "^1.10.0",
         "mysql2": "^3.12.0",
         "node-cron": "^3.0.3",
@@ -2325,6 +2327,18 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.46",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.46.tgz",
+      "integrity": "sha512-ZXm9b36esbe7OmdABqIWJuBBiLLwAjrN7CE+7sYdCCx82Nabt1wHDj8TVseS59QIlfFPbOoiBPm6ca9BioG4hw==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
       "engines": {
         "node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "express": "^4.21.2",
     "http-status-codes": "^2.3.0",
     "jsonwebtoken": "^9.0.2",
+    "moment": "^2.30.1",
+    "moment-timezone": "^0.5.46",
     "morgan": "^1.10.0",
     "mysql2": "^3.12.0",
     "node-cron": "^3.0.3",

--- a/prisma/migrations/20250120065915_/migration.sql
+++ b/prisma/migrations/20250120065915_/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `name` on the `Users` table. All the data in the column will be lost.
+  - Added the required column `title` to the `Alarms` table without a default value. This is not possible if the table is not empty.
+  - Made the column `challengeImage` on table `Challenges` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE `Alarms` ADD COLUMN `title` VARCHAR(30) NOT NULL;
+
+-- AlterTable
+ALTER TABLE `Challenges` ADD COLUMN `endDate` DATETIME(6) NULL,
+    ADD COLUMN `joinDate` DATETIME(6) NULL,
+    MODIFY `challengeImage` VARCHAR(255) NOT NULL;
+
+-- AlterTable
+ALTER TABLE `Users` DROP COLUMN `name`,
+    ADD COLUMN `nickname` VARCHAR(20) NULL DEFAULT '사용자',
+    MODIFY `phoneNumber` VARCHAR(15) NULL,
+    MODIFY `points` INTEGER NOT NULL DEFAULT 0;

--- a/prisma/migrations/20250120102557_/migration.sql
+++ b/prisma/migrations/20250120102557_/migration.sql
@@ -1,0 +1,66 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `obtain` on the `User_Badge` table. All the data in the column will be lost.
+  - You are about to drop the column `userCategory` on the `Users` table. All the data in the column will be lost.
+  - You are about to drop the `Board_Category` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Category` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Challenge_Category` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `category` to the `Boards` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `category` to the `Challenges` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `isObtained` to the `User_Badge` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `category` to the `User_CategoryType` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `category` to the `Users` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `Alarms` MODIFY `message` VARCHAR(255) NULL,
+    MODIFY `title` VARCHAR(120) NOT NULL;
+
+-- AlterTable
+ALTER TABLE `Boards` ADD COLUMN `category` ENUM('exercise', 'study', 'hobby', 'jobPreparation', 'lifestyle') NOT NULL,
+    MODIFY `name` VARCHAR(40) NOT NULL,
+    MODIFY `description` VARCHAR(255) NULL;
+
+-- AlterTable
+ALTER TABLE `Challenges` ADD COLUMN `category` ENUM('exercise', 'study', 'hobby', 'jobPreparation', 'lifestyle') NOT NULL,
+    MODIFY `name` VARCHAR(40) NULL,
+    MODIFY `description` VARCHAR(255) NULL;
+
+-- AlterTable
+ALTER TABLE `FavorType` MODIFY `name` VARCHAR(40) NULL;
+
+-- AlterTable
+ALTER TABLE `Keywords` MODIFY `name` VARCHAR(40) NULL;
+
+-- AlterTable
+ALTER TABLE `Posts` MODIFY `title` VARCHAR(100) NULL;
+
+-- AlterTable
+ALTER TABLE `TemporaryVerifications` MODIFY `title` VARCHAR(80) NULL,
+    MODIFY `content` VARCHAR(255) NULL;
+
+-- AlterTable
+ALTER TABLE `User_Badge` DROP COLUMN `obtain`,
+    ADD COLUMN `isObtained` BOOLEAN NOT NULL;
+
+-- AlterTable
+ALTER TABLE `User_CategoryType` ADD COLUMN `category` ENUM('exercise', 'study', 'hobby', 'jobPreparation', 'lifestyle') NOT NULL;
+
+-- AlterTable
+ALTER TABLE `Users` DROP COLUMN `userCategory`,
+    ADD COLUMN `category` ENUM('exercise', 'study', 'hobby', 'jobPreparation', 'lifestyle') NOT NULL,
+    MODIFY `phoneNumber` VARCHAR(40) NULL,
+    MODIFY `nickname` VARCHAR(40) NULL DEFAULT '사용자';
+
+-- AlterTable
+ALTER TABLE `Verifications` MODIFY `title` VARCHAR(80) NULL;
+
+-- DropTable
+DROP TABLE `Board_Category`;
+
+-- DropTable
+DROP TABLE `Category`;
+
+-- DropTable
+DROP TABLE `Challenge_Category`;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,10 +14,10 @@ model User {
   userBadge1_id          Int?
   userBadge2_id          Int?
   userBadge3_id          Int?
-  nickname               String?                 @db.VarChar(20) @default("사용자")
+  nickname               String?                 @db.VarChar(40) @default("사용자")
   gender                 Gender?
   email                  String                  @unique @db.VarChar(255)
-  phoneNumber            String?                 @db.VarChar(15)
+  phoneNumber            String?                 @db.VarChar(40)
   password               String                  @db.VarChar(255)
   created_at             DateTime                @default(now())
   updated_at             DateTime                @updatedAt
@@ -28,7 +28,7 @@ model User {
   followingCount         Int
   points                 Int                     @default(0)
   job                    Job?
-  userCategory           UserCategory?
+  category               Category
   ageGroup               AgeGroup?
   userBadge1             UserBadge?              @relation("Badge1", fields: [userBadge1_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
   userBadge2             UserBadge?              @relation("Badge2", fields: [userBadge2_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
@@ -56,7 +56,7 @@ model User {
 
 model Keyword {
   id                Int                @id @default(autoincrement())
-  name              String?            @db.VarChar(15)
+  name              String?            @db.VarChar(40)
   challengeKeywords ChallengeKeyword[]
 
   @@map("Keywords")
@@ -89,11 +89,11 @@ model Comment {
 
 model Board {
   id              Int             @id @default(autoincrement())
-  name            String          @db.VarChar(10)
-  description     String?         @db.VarChar(120)
+  name            String          @db.VarChar(40)
+  description     String?         @db.VarChar(255)
   boardStatus     BoardStatus     @map("status")
   posts           Post[]
-  boardCategories BoardCategory[]
+  category        Category
 
   @@map("Boards")
 }
@@ -102,7 +102,7 @@ model Post {
   id         Int        @id @default(autoincrement())
   user_id    Int
   board_id   Int
-  title      String?    @db.VarChar(50)
+  title      String?    @db.VarChar(100)
   content    String?    @db.VarChar(200)
   anonymous  Boolean?
   created_at DateTime?  @default(now())
@@ -144,7 +144,7 @@ model Verification {
   challengeType          ChallengeType
   verificationType       VerificationType        @map("type")
   photoUrl               String?                 @db.VarChar(255)
-  title                  String?                 @db.VarChar(20)
+  title                  String?                 @db.VarChar(80)
   content                String?                 @db.VarChar(200)
   question               Boolean?
   textUrl                String?                 @db.VarChar(255)
@@ -203,7 +203,7 @@ model UserBadge {
   user_id            Int
   badge_id           Int
   created_at         DateTime?            @default(now())
-  obtain             Boolean
+  isObtained         Boolean
   updated_at         DateTime?            @updatedAt
   user               User                 @relation(fields: [user_id], references: [id])
   badge              Badge                @relation(fields: [badge_id], references: [id])
@@ -215,17 +215,10 @@ model UserBadge {
   @@map("User_Badge")
 }
 
-model Category {
-  id                  Int                 @id @default(autoincrement())
-  name                String?             @db.VarChar(15)
-  userCategoryTypes   UserCategoryType[]
-  challengeCategories ChallengeCategory[]
-  boardCategories     BoardCategory[]
-}
 
 model FavorType {
   id                Int                @id @default(autoincrement())
-  name              String?            @db.VarChar(10)
+  name              String?            @db.VarChar(40)
   userCategoryTypes UserCategoryType[]
 }
 
@@ -235,33 +228,11 @@ model UserCategoryType {
   category_id  Int
   favorType_id Int
   user         User      @relation(fields: [user_id], references: [id])
-  category     Category  @relation(fields: [category_id], references: [id])
+  category     Category  
   favorType    FavorType @relation(fields: [favorType_id], references: [id])
 
   @@id([id, user_id, category_id, favorType_id])
   @@map("User_CategoryType")
-}
-
-model ChallengeCategory {
-  id           Int
-  category_id  Int
-  challenge_id Int
-  category     Category  @relation(fields: [category_id], references: [id])
-  challenge    Challenge @relation(fields: [challenge_id], references: [id])
-
-  @@id([id, category_id, challenge_id])
-  @@map("Challenge_Category")
-}
-
-model BoardCategory {
-  id          Int
-  board_id    Int
-  category_id Int
-  board       Board    @relation(fields: [board_id], references: [id])
-  category    Category @relation(fields: [category_id], references: [id])
-
-  @@id([id, board_id, category_id])
-  @@map("Board_Category")
 }
 
 model Scrap {
@@ -283,8 +254,8 @@ model TemporaryVerification {
   user_id         Int
   verification_id Int
   challengeType   ChallengeType
-  title           String?       @db.VarChar(20)
-  content         String?       @db.VarChar(200)
+  title           String?       @db.VarChar(80)
+  content         String?       @db.VarChar(255)
   created_at      DateTime?     @default(now())
   updated_at      DateTime?     @updatedAt
   user            User          @relation(fields: [user_id], references: [id])
@@ -296,9 +267,9 @@ model TemporaryVerification {
 model Challenge {
   id                  Int                 @id @default(autoincrement())
   owner_id            Int
-  name                String?             @db.VarChar(10)
+  name                String?             @db.VarChar(40)
   type                ChallengeType
-  description         String?             @db.VarChar(120)
+  description         String?             @db.VarChar(255)
   challengeImage      String              @db.VarChar(255)
   challengeStatus     ChallengeStatus     @map("status")
   maxParticipants     Int?
@@ -308,9 +279,9 @@ model Challenge {
   endDate             DateTime?           @db.DateTime(6)
   created_at          DateTime?           @db.DateTime(6)
   updated_at          DateTime?           @db.DateTime(6)
+  category            Category
   user                User                @relation(fields: [owner_id], references: [id])
   challengeLikes      ChallengeLike[]
-  challengeCategories ChallengeCategory[]
   frequencies         Frequency[]
   userChallenges      UserChallenge[]
   challengeKeywords   ChallengeKeyword[]
@@ -382,8 +353,8 @@ model Alarm {
   sender_id   Int?
   alarmType   AlarmType
   referenceId Int       @map("reference_id")
-  title       String    @db.VarChar(30)
-  message     String?   @db.VarChar(200)
+  title       String    @db.VarChar(120)
+  message     String?   @db.VarChar(255)
   isRead      Boolean?
   created_at  DateTime  @default(now())
   user        User      @relation(fields: [user_id], references: [id])
@@ -517,15 +488,16 @@ enum AgeGroup {
   fiftyUp @map("50s+")
 }
 
-enum UserCategory {
+
+enum BadgeType {
+  category
+  type
+}
+
+enum Category {
   exercise
   study
   hobby
   jobPreparation
   lifestyle
-}
-
-enum BadgeType {
-  category
-  type
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,10 +14,10 @@ model User {
   userBadge1_id          Int?
   userBadge2_id          Int?
   userBadge3_id          Int?
-  name                   String                  @db.VarChar(10)
+  nickname               String?                 @db.VarChar(20) @default("사용자")
   gender                 Gender?
   email                  String                  @unique @db.VarChar(255)
-  phoneNumber            String                  @db.VarChar(15)
+  phoneNumber            String?                 @db.VarChar(15)
   password               String                  @db.VarChar(255)
   created_at             DateTime                @default(now())
   updated_at             DateTime                @updatedAt
@@ -26,7 +26,7 @@ model User {
   level                  Level?
   followerCount          Int
   followingCount         Int
-  points                 Int
+  points                 Int                     @default(0)
   job                    Job?
   userCategory           UserCategory?
   ageGroup               AgeGroup?
@@ -299,11 +299,13 @@ model Challenge {
   name                String?             @db.VarChar(10)
   type                ChallengeType
   description         String?             @db.VarChar(120)
-  challengeImage      String?             @db.VarChar(255)
+  challengeImage      String              @db.VarChar(255)
   challengeStatus     ChallengeStatus     @map("status")
   maxParticipants     Int?
   verificationType    VerificationType
   rule                String?             @db.Text
+  joinDate            DateTime?           @db.DateTime(6)
+  endDate             DateTime?           @db.DateTime(6)
   created_at          DateTime?           @db.DateTime(6)
   updated_at          DateTime?           @db.DateTime(6)
   user                User                @relation(fields: [owner_id], references: [id])
@@ -380,6 +382,7 @@ model Alarm {
   sender_id   Int?
   alarmType   AlarmType
   referenceId Int       @map("reference_id")
+  title       String    @db.VarChar(30)
   message     String?   @db.VarChar(200)
   isRead      Boolean?
   created_at  DateTime  @default(now())

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,112 +1,153 @@
-import { PrismaClient } from '@prisma/client';
+import {
+  PrismaClient,
+  Gender,
+  Level,
+  Job,
+  AgeGroup,
+  Category,
+  VerificationType,
+  VerificationStatus,
+  ChallengeType,
+  ChallengeStatus,
+  AlarmType,
+  BadgeType,
+} from '@prisma/client';
+
 const prisma = new PrismaClient();
 
-const main = async () => {
-  console.log('Seeding database...');
-
-  // Users Table
-  await prisma.user.createMany({
-    data: [
-      {
-        name: 'John Doe',
-        gender: 'male',
-        email: 'john@example.com',
-        phoneNumber: '1234567890',
-        password: 'password123',
-        profilePhoto: 'https://example.com/profile1.jpg',
-        level: 'bronze',
-        followerCount: 10,
-        followingCount: 5,
-        points: 100,
-        job: 'officeWorker',
-        userCategory: 'exercise',
-        ageGroup: 'twenty',
-      },
-      {
-        name: 'Jane Smith',
-        gender: 'female',
-        email: 'jane@example.com',
-        phoneNumber: '0987654321',
-        password: 'password456',
-        profilePhoto: 'https://example.com/profile2.jpg',
-        level: 'silver',
-        followerCount: 20,
-        followingCount: 15,
-        points: 200,
-        job: 'collegeStudent',
-        userCategory: 'study',
-        ageGroup: 'thirty',
-      },
-    ],
+async function main() {
+  // 기본 사용자 추가
+  const user1 = await prisma.user.create({
+    data: {
+      nickname: '사용자1',
+      gender: Gender.male,
+      email: 'user1@example.com',
+      phoneNumber: '010-1234-5678',
+      password: 'password123',
+      followerCount: 10,
+      followingCount: 5,
+      points: 100,
+      job: Job.collegeStudent,
+      category: Category.study,
+      ageGroup: AgeGroup.twenty,
+      level: Level.silver,
+    },
   });
 
-  // Keywords Table
-  await prisma.keyword.createMany({
-    data: [
-      { name: 'motivation' },
-      { name: 'study' },
-      { name: 'health' },
-      { name: 'productivity' },
-    ],
+  const user2 = await prisma.user.create({
+    data: {
+      nickname: '사용자2',
+      gender: Gender.female,
+      email: 'user2@example.com',
+      phoneNumber: '010-9876-5432',
+      password: 'password456',
+      followerCount: 15,
+      followingCount: 10,
+      points: 200,
+      job: Job.officeWorker,
+      category: Category.exercise,
+      ageGroup: AgeGroup.thirty,
+      level: Level.gold,
+    },
   });
 
-  // Badges Table
-  await prisma.badge.createMany({
-    data: [
-      {
-        name: 'Starter Badge',
-        icon: 'https://example.com/badge1.png',
-        description: 'Awarded for starting your first challenge',
-        type: 'category',
-        obtainedCount: 100,
-        profileImage: 'https://example.com/badge1_profile.png',
-      },
-      {
-        name: 'Achiever Badge',
-        icon: 'https://example.com/badge2.png',
-        description: 'Awarded for completing 5 challenges',
-        type: 'type',
-        obtainedCount: 50,
-        profileImage: 'https://example.com/badge2_profile.png',
-      },
-    ],
+  // 배지 추가
+  const badge1 = await prisma.badge.create({
+    data: {
+      name: '최고의 사용자',
+      type: BadgeType.category,
+      obtainedCount: 50,
+    },
   });
 
-  // Challenges Table
-  await prisma.challenge.createMany({
-    data: [
-      {
-        owner_id: 1,
-        name: '매일 운동',
-        type: 'basic',
-        description: 'A challenge to exercise daily for 30 minutes',
-        challengeImage: 'https://example.com/challenge1.png',
-        challengeStatus: 'open',
-        maxParticipants: 50,
-        verificationType: 'camera',
-        rule: 'Submit a photo after exercise',
-      },
-      {
-        owner_id: 2,
-        name: '같이 공부',
-        type: 'study',
-        description: 'Study 2 hours every day for a week',
-        challengeImage: 'https://example.com/challenge2.png',
-        challengeStatus: 'ongoing',
-        maxParticipants: 30,
-        verificationType: 'text',
-        rule: 'Submit a text summary of what you studied',
-      },
-    ],
+  const badge2 = await prisma.badge.create({
+    data: {
+      name: '우수 참여자',
+      type: BadgeType.type,
+      obtainedCount: 30,
+    },
   });
 
-  // Other Tables (Add similar logic for other tables as needed)
-  console.log('Database seeded successfully!');
-};
+  // 사용자 배지 추가
+  await prisma.userBadge.create({
+    data: {
+      user_id: user1.id,
+      badge_id: badge1.id,
+      isObtained: true,
+    },
+  });
+
+  await prisma.userBadge.create({
+    data: {
+      user_id: user2.id,
+      badge_id: badge2.id,
+      isObtained: true,
+    },
+  });
+
+  // 챌린지 추가
+  const challenge = await prisma.challenge.create({
+    data: {
+      owner_id: user1.id,
+      name: '코딩 마스터 챌린지',
+      type: ChallengeType.study,
+      challengeImage: 'https://example.com/challenge-image.jpg',
+      challengeStatus: ChallengeStatus.ongoing,
+      verificationType: VerificationType.camera,
+      rule: '주어진 문제를 풀고 제출하세요.',
+      joinDate: new Date(),
+      endDate: new Date('2025-12-31'),
+      category: Category.study,
+    },
+  });
+
+  // 알람 추가
+  await prisma.alarm.create({
+    data: {
+      user_id: user1.id,
+      alarmType: AlarmType.follow,
+      title: '새로운 팔로워',
+      message: '사용자2님이 당신을 팔로우했습니다.',
+    },
+  });
+
+  // 검증 추가
+  const verification = await prisma.verification.create({
+    data: {
+      user_id: user1.id,
+      userChallenge_id: challenge.id,
+      challengeType: ChallengeType.study,
+      verificationType: VerificationType.text,
+      verificationStatus: VerificationStatus.unverified,
+      title: '코딩 문제 검증',
+      content: '주어진 코딩 문제를 풀었습니다.',
+      created_at: new Date(),
+      updated_at: new Date(),
+      deadline: new Date('2025-12-31'),
+    },
+  });
+
+  // 키워드 추가
+  const keyword = await prisma.keyword.create({
+    data: {
+      name: 'JavaScript',
+    },
+  });
+
+  // 챌린지와 키워드 연결
+  await prisma.challengeKeyword.create({
+    data: {
+      challenge_id: challenge.id,
+      keyword_id: keyword.id,
+    },
+  });
+
+  console.log('데이터 seeding 완료');
+}
 
 main()
-  .catch((e) => {
-    console.error('Error seeding database:', e);
+  .catch(e => {
+    console.error(e);
     process.exit(1);
   })
   .finally(async () => {

--- a/src/controllers/challenge/list.controller.js
+++ b/src/controllers/challenge/list.controller.js
@@ -1,3 +1,7 @@
+import { StatusCodes } from 'http-status-codes';
+import listDto from '../../dtos/challenge/list.dto.js';
+import listSerivce from '../../services/challenge/list.service.js';
+import logger from '../../logger.js';
 const getChallengeList = () => {
   /**
   #swagger.summary = '챌린지 리스트 조회 API';
@@ -300,7 +304,7 @@ const getChallengeDetail = () => {
   };
    */
 };
-const createChallenge = () => {
+const createChallenge = async (req, res, next) => {
   /**
   #swagger.summary = '챌린지 개설 API';
   #swagger.description = '사용자가 새로운 챌린지를 개설하는 API입니다. 카테고리, 유형, 사진, 기간, 제한 인원, 인증 수단, 규칙, 키워드를 포함합니다.';
@@ -443,6 +447,15 @@ const createChallenge = () => {
     }
   };
    */
+  try {
+    logger.debug('챌린지를 개설했습니다!');
+    console.log('body:', req.body); // 값이 잘 들어오나 확인하기 위한 테스트용
+
+    const challenge = await listSerivce.createChallenge(listDto.bodyToChallenge(req.body));
+    res.status(StatusCodes.OK).json({ result: challenge });
+  } catch (error) {
+    next(error);
+  }
 };
 
 export default {

--- a/src/dtos/challenge/list.dto.js
+++ b/src/dtos/challenge/list.dto.js
@@ -11,6 +11,7 @@ const bodyToChallenge = body => {
     type: body.type,
     description: body.description,
     challengeImage: body.challengeImage,
+    category: body.category,
     challengeStatus: body.challengeStatus,
     maxParticipants: body.maxParticipants,
     verificationType: body.verificationType,

--- a/src/dtos/challenge/list.dto.js
+++ b/src/dtos/challenge/list.dto.js
@@ -2,9 +2,9 @@ import { ChallengeStatus } from '@prisma/client';
 import moment from 'moment-timezone';
 
 const bodyToChallenge = body => {
-  const formattedJoinDate = moment.tz(body.joinDate, 'YYYY-MM-DD 00:00:00.000000', 'Asia/Seoul');
+  const formatted_JoinDate = moment.tz(body.joinDate, 'YYYY-MM-DD 00:00:00.000000', 'Asia/Seoul');
   console.log(formattedJoinDate);
-  const formattedEndDate = moment.tz(body.endDate, 'YYYY-MM-DD 00:00:00.000000', 'Asia/Seoul');
+  const formatted_EndDate = moment.tz(body.endDate, 'YYYY-MM-DD 00:00:00.000000', 'Asia/Seoul');
   return {
     name: body.name,
     owner_id: body.owner_id,
@@ -16,8 +16,8 @@ const bodyToChallenge = body => {
     maxParticipants: body.maxParticipants,
     verificationType: body.verificationType,
     rule: body.rule,
-    joinDate: formattedJoinDate,
-    endDate: formattedEndDate,
+    joinDate: formatted_JoinDate,
+    endDate: formatted_EndDate,
   };
 };
 

--- a/src/dtos/challenge/list.dto.js
+++ b/src/dtos/challenge/list.dto.js
@@ -1,0 +1,25 @@
+import { ChallengeStatus } from '@prisma/client';
+import moment from 'moment-timezone';
+
+const bodyToChallenge = body => {
+  const formattedJoinDate = moment.tz(body.joinDate, 'YYYY-MM-DD 00:00:00.000000', 'Asia/Seoul');
+  console.log(formattedJoinDate);
+  const formattedEndDate = moment.tz(body.endDate, 'YYYY-MM-DD 00:00:00.000000', 'Asia/Seoul');
+  return {
+    name: body.name,
+    owner_id: body.owner_id,
+    type: body.type,
+    description: body.description,
+    challengeImage: body.challengeImage,
+    challengeStatus: body.challengeStatus,
+    maxParticipants: body.maxParticipants,
+    verificationType: body.verificationType,
+    rule: body.rule,
+    joinDate: formattedJoinDate,
+    endDate: formattedEndDate,
+  };
+};
+
+export default {
+  bodyToChallenge,
+};

--- a/src/errors/challenge/list.error.js
+++ b/src/errors/challenge/list.error.js
@@ -1,0 +1,48 @@
+export class CreateChallengeError extends Error {
+  errorCode = 'B001';
+  constructor(reason, data) {
+    super(reason);
+    this.reason = reason;
+    this.statuscode = 400;
+    this.data = data;
+  }
+}
+
+export class SendChallengeError extends Error {
+  errorCode = 'B002';
+  constructor(reason, data) {
+    super(reason);
+    this.reason = reason;
+    this.statuscode = 400;
+    this.data = data;
+  }
+}
+
+//인증 실패 오류
+export class ChallengeExpiredError extends Error {
+  errorCode = 'B003';
+  constructor(reason, data) {
+    super(reason);
+    this.reason = reason;
+    this.statuscode = 400;
+    this.data = data;
+  }
+}
+
+//서버오류
+export class DataBaseError extends Error {
+  errorCode = 'B004';
+  constructor(reason, data) {
+    super(reason);
+    this.reason = reason;
+    this.statuscode = 400;
+    this.data = data;
+  }
+}
+
+export default {
+  CreateChallengeError,
+  DataBaseError,
+  ChallengeExpiredError,
+  SendChallengeError,
+};

--- a/src/repositories/challenge/list.repository.js
+++ b/src/repositories/challenge/list.repository.js
@@ -1,0 +1,19 @@
+import { prisma } from '../../db.config.js';
+import listError from '../../errors/challenge/list.error.js';
+
+//챌린지 생성 함수
+const createChallenge = async data => {
+  try {
+    const created_challenge = await prisma.challenge.create({
+      data: data,
+    });
+    return created_challenge;
+  } catch (error) {
+    console.log(error);
+    throw new listError.DataBaseError('Error on creating challenge');
+  }
+};
+
+export default {
+  createChallenge,
+};

--- a/src/services/challenge/list.service.js
+++ b/src/services/challenge/list.service.js
@@ -1,0 +1,10 @@
+import listRepository from '../../repositories/challenge/list.repository.js';
+
+const createChallenge = async data => {
+  const created_challenge = await listRepository.createChallenge(data);
+  return created_challenge;
+};
+
+export default {
+  createChallenge,
+};


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- 챌린지 생성하는 API 구현
- 데이터베이스 수정

## 🔍 작업 상세 (Implementation Details)
- repository, dto, controller, service 구현
- 데이터베이스 수정:
name -> nickname 변경
사용자 이메일 비밀번호 제외하고 NULL 로 가능
challenge 테이블에 시작일과 종료일 입력
챌린지 이미지 필수
알림에 title 추가
points default 0

