### PR TITLE
Feat: Add Create Board API

### DIFF
--- a/prisma/migrations/20250121100106_/migration.sql
+++ b/prisma/migrations/20250121100106_/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE `Boards` MODIFY `status` BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE `UserBoard` MODIFY `pinned` BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,7 +91,7 @@ model UserBoard {
   id        Int       @id @default(autoincrement())
   userId    Int
   boardId   Int
-  pinned    Boolean
+  pinned    Boolean   @default(false)
   user      User      @relation(fields: [userId], references: [id])
   board     Board     @relation(fields: [boardId], references: [id])
 
@@ -104,7 +104,7 @@ model Board {
   name        String       @db.VarChar(40)
   description String?      @db.VarChar(255)
   posts       Post[]
-  status      Boolean
+  status      Boolean      @default(false)
   category    Category
   userBoards  UserBoard[]
   

--- a/src/controllers/board.controller.js
+++ b/src/controllers/board.controller.js
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 import boardService from '../services/board.service.js';
-
+import boardDto from '../dtos/board.dto.js';
 const getBoardCategories = async (req, res, next) => {
   /**
   #swagger.summary = '게시판 카테고리 목록 조회 API';
@@ -87,7 +87,7 @@ const getBoardCategories = async (req, res, next) => {
   }
 };
 
-const createBoard = () => {
+const createBoard = async (req, res, next) => {
   /**
   #swagger.summary = '게시판 생성 API';
   #swagger.description = '사용자가 새로운 게시판을 생성하는 API입니다.';
@@ -186,7 +186,14 @@ const createBoard = () => {
     }
   };
    */
+  try {
+    const new_board = await boardService.createBoard(boardDto.createBoardResponseDto(req.body));
+    return res.status(StatusCodes.OK).json(new_board);
+  } catch (error) {
+    next(error);
+  }
 };
+
 const pinBoard = async (req, res, next) => {
   /**
   #swagger.summary = '게시판 상단 고정 API';

--- a/src/dtos/board.dto.js
+++ b/src/dtos/board.dto.js
@@ -1,3 +1,5 @@
+import { create } from 'domain';
+
 const getBoardsFromUser = user_board => {
   const board_categories = [];
 
@@ -9,6 +11,16 @@ const getBoardsFromUser = user_board => {
   return board_categories;
 };
 
+const createBoardResponseDto = body => {
+  const new_board_info = {
+    name: body.name,
+    description: body.description,
+    category: body.category,
+  };
+  return new_board_info;
+};
+
 export default {
   getBoardsFromUser,
+  createBoardResponseDto,
 };

--- a/src/repositories/board.repository.js
+++ b/src/repositories/board.repository.js
@@ -49,7 +49,19 @@ const patchBoardPinStatus = async (board_id, status) => {
   }
 };
 
+const createBoard = async new_board_info => {
+  try {
+    const created_board = await prisma.board.create({
+      data: new_board_info,
+    });
+    return created_board;
+  } catch (error) {
+    throw new boardError.DataBaseError('Error on creating board');
+  }
+};
+
 export default {
   getUserBoard,
   patchBoardPinStatus,
+  createBoard,
 };

--- a/src/routes/board.routes.js
+++ b/src/routes/board.routes.js
@@ -4,7 +4,7 @@ import authMiddleware from '../middlewares/auth.middleware.js';
 const router = express.Router();
 
 router.get('/categories', authMiddleware, boardController.getBoardCategories);
-router.post('/', boardController.createBoard);
+router.post('/', authMiddleware, boardController.createBoard);
 router.patch('/:boardId/pin', authMiddleware, boardController.pinBoard);
 router.patch('/:boardId/unpin', authMiddleware, boardController.unpinBoard);
 router.get('/:boardId/hotness', boardController.getBoardHotPosts);

--- a/src/services/board.service.js
+++ b/src/services/board.service.js
@@ -1,5 +1,6 @@
 import boardRepository from '../repositories/board.repository.js';
 import boardDto from '../dtos/board.dto.js';
+import { create } from 'domain';
 
 const getBoardCategories = async user_email => {
   const user_board = await boardRepository.getUserBoard(user_email);
@@ -26,7 +27,13 @@ const patchBoardPinStatus = async (board_id, status) => {
   return pinned;
 };
 
+const createBoard = async new_board_info => {
+  const new_board = await boardRepository.createBoard(new_board_info);
+  return new_board;
+};
+
 export default {
   getBoardCategories,
   patchBoardPinStatus,
+  createBoard,
 };


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- 게시판을 추가하는 API를 구현합니다.

## 🔍 작업 상세 (Implementation Details)
- Board table의 status값의 default값을 0으로 추가하였습니다.
- UserBoard table의 pinned 값의 default값을 0으로 추가하였습니다.
- response
```json
{
    "id": 7,
    "name": "축구게시판",
    "description": "축구할사람~",
    "status": false,
    "category": "exercise"
}
```