### PR TITLE
Feat: Add get challenge detail API

### DIFF
--- a/prisma/migrations/20250121163633_/migration.sql
+++ b/prisma/migrations/20250121163633_/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `duration` to the `Challenges` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `Challenges` ADD COLUMN `duration` ENUM('week_1', 'week_2', 'week_3', 'month_1', 'month_2', 'month_3') NOT NULL;
+
+-- AlterTable
+ALTER TABLE `User_Challenge` MODIFY `status` ENUM('kick', 'active') NOT NULL DEFAULT 'active';

--- a/src/controllers/challenge/list.controller.js
+++ b/src/controllers/challenge/list.controller.js
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 import listDto from '../../dtos/challenge/list.dto.js';
-import listSerivce from '../../services/challenge/list.service.js';
+import listService from '../../services/challenge/list.service.js';
 import logger from '../../logger.js';
 const getChallengeList = () => {
   /**
@@ -194,7 +194,7 @@ const searchChallenge = () => {
   };
    */
 };
-const getChallengeDetail = () => {
+const getChallengeDetail = async (req, res, next) => {
   /**
   #swagger.summary = '챌린지 검색 API';
   #swagger.description = '사용자가 특정 조건에 따라 챌린지를 검색하는 API입니다. 검색 조건은 쿼리 스트링을 사용합니다.';
@@ -303,7 +303,16 @@ const getChallengeDetail = () => {
     }
   };
    */
+  try {
+    const challenge_id = parseInt(req.params.challengeId, 10);
+    const challenge_info = await listService.getChallengeDetailById(challenge_id);
+
+    return res.status(StatusCodes.OK).json(challenge_info);
+  } catch (error) {
+    next(error);
+  }
 };
+
 const createChallenge = async (req, res, next) => {
   /**
   #swagger.summary = '챌린지 개설 API';
@@ -450,7 +459,7 @@ const createChallenge = async (req, res, next) => {
   try {
     logger.debug('챌린지를 개설했습니다!');
 
-    const challenge = await listSerivce.createChallenge(listDto.bodyToChallenge(req.body));
+    const challenge = await listService.createChallenge(listDto.bodyToChallenge(req.body));
     res.status(StatusCodes.OK).json({ result: challenge });
   } catch (error) {
     next(error);

--- a/src/errors/challenge/list.error.js
+++ b/src/errors/challenge/list.error.js
@@ -40,9 +40,20 @@ export class DataBaseError extends Error {
   }
 }
 
+export class ChallengeIdNotExistsError extends Error {
+  errorCode = 'B005';
+  constructor(reason, data) {
+    super(reason);
+    this.reason = reason;
+    this.statuscode = 400;
+    this.data = data;
+  }
+}
+
 export default {
   CreateChallengeError,
   DataBaseError,
   ChallengeExpiredError,
   SendChallengeError,
+  ChallengeIdNotExistsError,
 };

--- a/src/repositories/challenge/list.repository.js
+++ b/src/repositories/challenge/list.repository.js
@@ -13,6 +13,14 @@ const createChallenge = async data => {
   }
 };
 
+const getChallengeDetailById = async challenge_id => {
+  const challenge_info = await prisma.challenge.findUnique({
+    where: { id: challenge_id },
+  });
+  return challenge_info;
+};
+
 export default {
   createChallenge,
+  getChallengeDetailById,
 };

--- a/src/routes/challenge.routes.js
+++ b/src/routes/challenge.routes.js
@@ -2,6 +2,7 @@ import express from 'express';
 import categoryController from '../controllers/challenge/category.controller.js';
 import listController from '../controllers/challenge/list.controller.js';
 import participationController from '../controllers/challenge/participation.controller.js';
+import authMiddleware from '../middlewares/auth.middleware.js';
 
 const router = express.Router();
 
@@ -12,7 +13,7 @@ router.get('/hotness', categoryController.getWeeklyHotChallenge);
 // List and Detail
 router.get('/', listController.getChallengeList);
 router.get('/search', listController.searchChallenge);
-router.get('/:challengeId', listController.getChallengeDetail);
+router.get('/:challengeId', authMiddleware, listController.getChallengeDetail);
 router.post('/', listController.createChallenge);
 
 // Participation

--- a/src/services/challenge/list.service.js
+++ b/src/services/challenge/list.service.js
@@ -1,10 +1,19 @@
 import listRepository from '../../repositories/challenge/list.repository.js';
-
+import listError from '../../errors/challenge/list.error.js';
 const createChallenge = async data => {
   const created_challenge = await listRepository.createChallenge(data);
   return created_challenge;
 };
 
+const getChallengeDetailById = async challenge_id => {
+  const challenge_detail = await listRepository.getChallengeDetailById(challenge_id);
+  if (!challenge_detail) {
+    throw new listError.ChallengeIdNotExistsError('해당 id의 챌린지는 존재하지 않습니다.', challenge_id);
+  }
+  return challenge_detail;
+};
+
 export default {
   createChallenge,
+  getChallengeDetailById,
 };


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- 챌린지 세부정보를 호출하는 API를 구현하였습니다.

## 🔍 작업 상세 (Implementation Details)
- response 예시
```json
{
  "resultType": "SUCCESS",
  "error": null,
  "success": {
    "id": 10,
    "owner_id": 1,
    "name": null,
    "type": "study",
    "description": "30일 동안 하루 한 권의 책을 읽는 챌린지입니다.",
    "challengeImage": "https://example.com/images/reading-challenge.jpg",
    "challengeStatus": "ongoing",
    "maxParticipants": 100,
    "verificationType": "camera",
    "rule": "매일 독서 인증 사진을 업로드하세요.",
    "joinDate": "2024-12-31T15:00:00.000Z",
    "endDate": "2025-01-29T15:00:00.000Z",
    "created_at": null,
    "updated_at": null,
    "category": "hobby"
  }
}
```
