### PR TITLE
Fix: Database changed

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,7 @@ model User {
   receivedMessages       Message[]               @relation("ReceivedMessages")
   sentMessages           Message[]               @relation("SentMessages")
   userBoards             UserBoard[] 
+  userAgreements         UserAgreement[]
   @@map("Users")
 }
 
@@ -78,11 +79,15 @@ model Comment {
   post_id         Int
   verification_id Int
   content         String?      @db.Text
+  parent_id       Int?         //부모 댓글 ID(NULL일 때는 최상위 댓글)
+  depth           Int          @default(0) //최상위 댓글은 0
   created_at      DateTime?    @db.DateTime(6)
   updated_at      DateTime?    @db.DateTime(6)
   user            User         @relation(fields: [user_id], references: [id])
   post            Post         @relation(fields: [post_id], references: [id])
   verification    Verification @relation(fields: [verification_id], references: [id])
+  parent_comment  Comment?     @relation("CommentReplies", fields:[parent_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  child_comment   Comment[]    @relation("CommentReplies")
 
   @@map("Comments")
 }
@@ -165,6 +170,7 @@ model Verification {
   created_at             DateTime?               @default(now())
   updated_at             DateTime?               @updatedAt
   deadline               DateTime?               @db.DateTime(6)
+  adoptionComplete       Boolean                 @default(false)
   user                   User                    @relation(fields: [user_id], references: [id])
   userChallenge          UserChallenge           @relation(fields: [userChallenge_id], references: [id])
   comments               Comment[]
@@ -306,7 +312,13 @@ model Frequency {
   id             Int           @id @default(autoincrement())
   challenge_id   Int
   frequencyType  FrequencyType
-  frequencyValue String?       @db.LongText
+  monday         Boolean       @default(false)
+  tuesday        Boolean       @default(false)
+  wednesday      Boolean       @default(false)
+  thursday       Boolean       @default(false)
+  friday         Boolean       @default(false)
+  saturday       Boolean       @default(false)
+  sunday         Boolean       @default(false)
   challenge      Challenge     @relation(fields: [challenge_id], references: [id])
 
   @@map("Frequencies")
@@ -405,6 +417,21 @@ model EmailVerification {
   verified         Boolean  @default(false)
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
+}
+
+model UserAgreement {
+  id                  Int      @id @default(autoincrement())
+  user_id             Int
+  user                User     @relation(fields: [user_id], references: [id])
+  agree_all           Boolean  @default(false) @map("agreeAll")
+  terms_of_service    Boolean  @default(false) @map("termsOfService")
+  privacy_policy      Boolean  @default(false) @map("privacyPolicy")
+  third_party_provision Boolean @default(false) @map("thirdPartyProvision")
+  marketing_and_ads   Boolean  @default(false) @map("marketingAndAds")
+  created_at          DateTime @default(now())
+  updated_at          DateTime @updatedAt
+
+  @@map("UserAgreements")
 }
 
 enum AlarmType {


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- 대댓글 데이터베이스를 추가합니다.
- 채택 데이터베이스를 추가합니다.
- 사용자약관 동의를 추가합니다.
- 스터디 챌리지와 베이직 챌린지의 인증빈도와 요일을 수정합니다.

## 🔍 작업 상세 (Implementation Details)
- 대댓글: 부모 댓글과 자식 댓글로 분류해서 사용자 id가 각각 전달될 수  있도록 합니다. (NULL 일 때가 최상위 댓글) & depth 를 추가해서 로직을 구현할 수 있도록 합니다. (최상위 댓글은 0) & parent_comment 와 child_comment를 생성해서 CommentReplies로 관계를 맺어둡니다.
- 채택: 인증글에 adoptionComplete 컬럼을 추가합니다.
- 사용자 약관 동의 테이블과 컬럼을 추가합니다. (총 5개)
- frequencyValue를 삭제하고 월,화,수,목,금,토,일을 추가합니다.
