### PR TITLE
Feat/scrap verification api

### DIFF
--- a/prisma/migrations/20250130183417_/migration.sql
+++ b/prisma/migrations/20250130183417_/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Scraps` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE `Scraps`;
+
+-- CreateTable
+CREATE TABLE `VerificationScraps` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `user_id` INTEGER NOT NULL,
+    `verification_id` INTEGER NOT NULL,
+
+    UNIQUE INDEX `VerificationScraps_user_id_verification_id_key`(`user_id`, `verification_id`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/migrations/20250130190033_/migration.sql
+++ b/prisma/migrations/20250130190033_/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE `Verifications` ADD COLUMN `commentsCount` INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN `scrapsCount` INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,7 +39,7 @@ model User {
   verifications          Verification[]
   userBadges             UserBadge[]
   userCategoryTypes      UserCategoryType[]
-  scraps                 Scrap[]
+  verificationScraps     VerificationScrap[]
   temporaryVerifications TemporaryVerification[]
   challenges             Challenge[]
   userChallenges         UserChallenge[]
@@ -173,10 +173,11 @@ model Verification {
   userChallenge          UserChallenge           @relation(fields: [userChallenge_id], references: [id])
   comments               Comment[]
   temporaryVerifications TemporaryVerification[]
-  scrapTarget1           Scrap[]                 @relation("ScrapTarget1")
-  scrapTarget2           Scrap[]                 @relation("ScrapTarget2")
-  likesCount             Int                     @default(0) // 좋아요 개수 필드 추가
+  likesCount             Int                     @default(0)
+  scrapsCount            Int                     @default(0)
+  commentsCount          Int                     @default(0)
   verificationLikes      VerificationLike[]
+  VerificationScrap      VerificationScrap[]
 
   @@map("Verifications")
 }
@@ -266,18 +267,16 @@ model UserCategoryType {
   @@map("User_CategoryType")
 }
 
-model Scrap {
-  id              Int           @id @default(autoincrement())
+model VerificationScrap {
+  id              Int          @id @default(autoincrement())
   user_id         Int
-  scrapTarget1_id Int
-  scrapTarget2_id Int
-  scrapType       ScrapType
-  created_at      DateTime?     @default(now())
-  user            User          @relation(fields: [user_id], references: [id])
-  scrapTarget1    Verification? @relation("ScrapTarget1", fields: [scrapTarget1_id], references: [id])
-  scrapTarget2    Verification? @relation("ScrapTarget2", fields: [scrapTarget2_id], references: [id])
+  verification_id Int
 
-  @@map("Scraps")
+  user           User          @relation(fields: [user_id], references: [id])
+  verification   Verification  @relation(fields: [verification_id], references: [id])
+
+  @@unique([user_id, verification_id])
+  @@map("VerificationScraps")
 }
 
 model TemporaryVerification {
@@ -486,11 +485,6 @@ enum VerificationType {
 enum VerificationStatus {
   certified
   uncertified
-}
-
-enum ScrapType {
-  post
-  verification
 }
 
 enum ChallengeStatus {

--- a/src/controllers/verification/scrap.controller.js
+++ b/src/controllers/verification/scrap.controller.js
@@ -125,7 +125,8 @@ export const scrapVerification = async (req, res, next) => {
     next(error);
   }
 };
-export const unscrapVerification = () => {
+
+export const unscrapVerification = async (req, res, next) => {
   /**
   #swagger.summary = '특정 인증 스크랩 취소 API';
   #swagger.description = '특정 챌린지 인증에 추가된 스크랩을 취소하는 API입니다.';
@@ -243,6 +244,14 @@ export const unscrapVerification = () => {
     }
   };
    */
+  try {
+    const user_id = req.user.id;
+    const verification_id = Number(req.params.verificationId);
+    const unscrap_verification = await scrapService.unscrapVerification(user_id, verification_id);
+    return res.status(StatusCodes.OK).json(unscrap_verification);
+  } catch (error) {
+    next(error);
+  }
 };
 
 export default {

--- a/src/controllers/verification/scrap.controller.js
+++ b/src/controllers/verification/scrap.controller.js
@@ -12,12 +12,6 @@ export const scrapVerification = async (req, res, next) => {
     schema: { type: 'string', example: 'Bearer {token}' },
     description: '인증을 위한 액세스 토큰'
   };
-  #swagger.parameters['challengeId'] = {
-    in: 'path',
-    required: true,
-    schema: { type: 'string', example: '101' },
-    description: '챌린지 ID'
-  };
   #swagger.parameters['verificationId'] = {
     in: 'path',
     required: true,
@@ -48,11 +42,9 @@ export const scrapVerification = async (req, res, next) => {
             success: {
               type: 'object',
               properties: {
-                scrapId: { type: 'string', example: '202' },
-                userId: { type: 'string', example: 'user1' },
-                verificationId: { type: 'string', example: '101' },
-                scrapCount: { type: 'integer', example: 5 },
-                message: { type: 'string', example: 'Scrap added successfully.' }
+                verificationId: { type: 'integer', example: 101 },
+                userId: { type: 'integer', example: 1},
+                likesCount: { type: 'integer', example: 3 },
               }
             }
           }
@@ -144,12 +136,6 @@ export const unscrapVerification = () => {
     schema: { type: 'string', example: 'Bearer {token}' },
     description: '인증을 위한 액세스 토큰'
   };
-  #swagger.parameters['challengeId'] = {
-    in: 'path',
-    required: true,
-    schema: { type: 'string', example: '101' },
-    description: '챌린지 ID'
-  };
   #swagger.parameters['verificationId'] = {
     in: 'path',
     required: true,
@@ -183,11 +169,9 @@ export const unscrapVerification = () => {
             success: {
               type: 'object',
               properties: {
-                scrapId: { type: 'string', example: '202' },
-                userId: { type: 'string', example: 'user1' },
-                verificationId: { type: 'string', example: '101' },
-                scrapCount: { type: 'integer', example: 4 },
-                message: { type: 'string', example: 'Scrap removed successfully.' }
+                verificationId: { type: 'integer', example: 101 },
+                userId: { type: 'integer', example: 1},
+                likesCount: { type: 'integer', example: 3 },
               }
             }
           }

--- a/src/controllers/verification/scrap.controller.js
+++ b/src/controllers/verification/scrap.controller.js
@@ -1,4 +1,7 @@
-export const scrapVerification = () => {
+import { StatusCodes } from 'http-status-codes';
+import scrapService from '../../services/verification/scrap.service.js';
+
+export const scrapVerification = async (req, res, next) => {
   /**
   #swagger.summary = '특정 인증 스크랩 API';
   #swagger.description = '특정 챌린지 인증을 스크랩하는 API입니다.';
@@ -121,6 +124,14 @@ export const scrapVerification = () => {
     }
   };
    */
+  try {
+    const user_id = req.user.id;
+    const verification_id = Number(req.params.verificationId);
+    const scrap_verification = await scrapService.scrapVerification(user_id, verification_id);
+    return res.status(StatusCodes.OK).json(scrap_verification);
+  } catch (error) {
+    next(error);
+  }
 };
 export const unscrapVerification = () => {
   /**

--- a/src/dtos/verification/scrap.dto.js
+++ b/src/dtos/verification/scrap.dto.js
@@ -1,0 +1,9 @@
+const scrapVerificationServiceToController = data => {
+  const response_data = {
+    user_id: data[0].user_id,
+    verification_id: data[0].verification_id,
+    scrapsCount: data[1].scrapsCount,
+  };
+  return response_data;
+};
+export default { scrapVerificationServiceToController };

--- a/src/errors/verification/scrap.error.js
+++ b/src/errors/verification/scrap.error.js
@@ -1,0 +1,35 @@
+export class VerificationAlreadyScrapedError extends Error {
+  errorCode = 'S001';
+  constructor(reason, data) {
+    super(reason);
+    this.reason = reason;
+    this.statuscode = 400;
+    this.data = data;
+  }
+}
+
+export class VerificationNotScrapedError extends Error {
+  errorCode = 'S002';
+  constructor(reason, data) {
+    super(reason);
+    this.reason = reason;
+    this.statuscode = 400;
+    this.data = data;
+  }
+}
+
+export class VerificationScrapsUnderZeroError extends Error {
+  errorCode = 'S003';
+  constructor(reason, data) {
+    super(reason);
+    this.reason = reason;
+    this.statuscode = 400;
+    this.data = data;
+  }
+}
+
+export default {
+  VerificationAlreadyScrapedError,
+  VerificationNotScrapedError,
+  VerificationScrapsUnderZeroError,
+};

--- a/src/repositories/verification/like.repository.js
+++ b/src/repositories/verification/like.repository.js
@@ -41,7 +41,7 @@ const unlikeVerification = async (user_id, verification_id) => {
     if (error.code === 'P2025') {
       throw new likeError.VerificationLikesUnderZeroError('좋아요 개수가 음수가 되었습니다.');
     }
-    throw new databaseError.DataBaseError('Database error occurred while following user');
+    throw new databaseError.DataBaseError('Database error occurred while unliking verification');
   }
 };
 

--- a/src/repositories/verification/scrap.repository.js
+++ b/src/repositories/verification/scrap.repository.js
@@ -1,0 +1,47 @@
+import { prisma } from '../../db.config.js';
+import databaseError from '../../errors/database.error.js';
+import scrapError from '../../errors/verification/scrap.error.js';
+
+const scrapVerification = async (user_id, verification_id) => {
+  try {
+    return await prisma.$transaction([
+      prisma.verificationScrap.create({
+        data: {
+          user_id: user_id,
+          verification_id: verification_id,
+        },
+      }),
+      prisma.verification.update({
+        where: { id: verification_id },
+        data: { scrapsCount: { increment: 1 } },
+      }),
+    ]);
+  } catch (error) {
+    throw new databaseError.DataBaseError('Database error occurred while following user');
+  }
+};
+
+const checkVerificationScraped = async (user_id, verification_id) => {
+  try {
+    const verification_scraped = await prisma.verificationScrap.findUnique({
+      where: {
+        user_id_verification_id: {
+          user_id,
+          verification_id,
+        },
+      },
+    });
+    if (verification_scraped) {
+      return true;
+    } else {
+      return false;
+    }
+  } catch (error) {
+    throw new databaseError.DataBaseError('Database error occurred while following user');
+  }
+};
+
+export default {
+  scrapVerification,
+  checkVerificationScraped,
+};

--- a/src/routes/verification.routes.js
+++ b/src/routes/verification.routes.js
@@ -33,6 +33,6 @@ router.patch('/:challengeId/verification/:verificationId/comment', commentContro
 
 // Scrap
 router.post('/:verificationId/scrap', authMiddleware, scrapController.scrapVerification);
-router.delete('/:verificationId/scrap', authMiddleware, scrapController.unscrapVerification);
+router.delete('/:verificationId/unscrap', authMiddleware, scrapController.unscrapVerification);
 
 export default router;

--- a/src/routes/verification.routes.js
+++ b/src/routes/verification.routes.js
@@ -32,7 +32,7 @@ router.post('/:challengeId/verification/:verificationId/comment', commentControl
 router.patch('/:challengeId/verification/:verificationId/comment', commentController.updateVerificationComment);
 
 // Scrap
-router.post('/:challengeId/verification/:verificationId/scrap', scrapController.scrapVerification);
-router.delete('/:challengeId/verification/:verificationId/scrap', scrapController.unscrapVerification);
+router.post('/:verificationId/scrap', authMiddleware, scrapController.scrapVerification);
+router.delete('/:verificationId/scrap', authMiddleware, scrapController.unscrapVerification);
 
 export default router;

--- a/src/services/verification/scrap.service.js
+++ b/src/services/verification/scrap.service.js
@@ -12,6 +12,17 @@ const scrapVerification = async (user_id, verification_id) => {
   return scrap_verification_response;
 };
 
+const unscrapVerification = async (user_id, verification_id) => {
+  const is_verification_scraped = await scrapRepository.checkVerificationScraped(user_id, verification_id);
+  if (!is_verification_scraped) {
+    throw new scrapError.VerificationNotScrapedError('해당 인증은 이미 스크랩되어 있습니다.');
+  }
+  const unscrap_verification = await scrapRepository.unscrapVerification(user_id, verification_id);
+  const unscrap_verification_response = scrapDto.scrapVerificationServiceToController(unscrap_verification);
+  return unscrap_verification_response;
+};
+
 export default {
   scrapVerification,
+  unscrapVerification,
 };

--- a/src/services/verification/scrap.service.js
+++ b/src/services/verification/scrap.service.js
@@ -1,0 +1,17 @@
+import scrapRepository from '../../repositories/verification/scrap.repository.js';
+import scrapError from '../../errors/verification/scrap.error.js';
+import scrapDto from '../../dtos/verification/scrap.dto.js';
+
+const scrapVerification = async (user_id, verification_id) => {
+  const is_verification_scraped = await scrapRepository.checkVerificationScraped(user_id, verification_id);
+  if (is_verification_scraped) {
+    throw new scrapError.VerificationAlreadyScrapedError('해당 인증은 이미 스크랩되어 있습니다.');
+  }
+  const scrap_verification = await scrapRepository.scrapVerification(user_id, verification_id);
+  const scrap_verification_response = scrapDto.scrapVerificationServiceToController(scrap_verification);
+  return scrap_verification_response;
+};
+
+export default {
+  scrapVerification,
+};


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- 인증을 스크랩, 스크랩 취소하는 api를 구현합니다.

## 🔍 작업 상세 (Implementation Details)
- DB를 수정했습니다.
    - scrap 테이블을 삭제했습니다.
    - verificaitonScrap 테이블을 생성했습니다.
    - verification 테이블에 scrapsCount를 추가했습니다.
- `POST /api/v1/verification/{verificationId}/scrap`를 구현했습니다.
- `DELETE /api/v1/verification/{verificationId}/unscrap`를 구현했습니다.
