### PR TITLE
Feat/#84 add verification comment api

### DIFF
--- a/prisma/migrations/20250131081919_/migration.sql
+++ b/prisma/migrations/20250131081919_/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE `Comments` MODIFY `post_id` INTEGER NULL,
+    MODIFY `verification_id` INTEGER NULL;

--- a/prisma/migrations/20250131084327_/migration.sql
+++ b/prisma/migrations/20250131084327_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Comments` MODIFY `created_at` DATETIME(6) NULL DEFAULT CURRENT_TIMESTAMP(6);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,16 +76,16 @@ model ChallengeLike {
 model Comment {
   id              Int          @id @default(autoincrement())
   user_id         Int
-  post_id         Int
-  verification_id Int
+  post_id         Int?
+  verification_id Int?
   content         String?      @db.Text
-  parent_id       Int?         //부모 댓글 ID(NULL일 때는 최상위 댓글)
+  parent_id       Int?
   anonymous       Boolean      @default(false)
   created_at      DateTime?    @db.DateTime(6)
   updated_at      DateTime?    @db.DateTime(6)
   user            User         @relation(fields: [user_id], references: [id])
-  post            Post         @relation(fields: [post_id], references: [id])
-  verification    Verification @relation(fields: [verification_id], references: [id])
+  post            Post?        @relation(fields: [post_id], references: [id])
+  verification    Verification? @relation(fields: [verification_id], references: [id])
   parent_comment  Comment?     @relation("CommentReplies", fields:[parent_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
   child_comment   Comment[]    @relation("CommentReplies")
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,8 +81,8 @@ model Comment {
   content         String?      @db.Text
   parent_id       Int?
   anonymous       Boolean      @default(false)
-  created_at      DateTime?    @db.DateTime(6)
-  updated_at      DateTime?    @db.DateTime(6)
+  created_at      DateTime?    @db.DateTime(6) @default(now())
+  updated_at      DateTime?    @db.DateTime(6) @updatedAt
   user            User         @relation(fields: [user_id], references: [id])
   post            Post?        @relation(fields: [post_id], references: [id])
   verification    Verification? @relation(fields: [verification_id], references: [id])

--- a/src/controllers/verification/comment.controller.js
+++ b/src/controllers/verification/comment.controller.js
@@ -1,3 +1,8 @@
+import { StatusCodes } from 'http-status-codes';
+import commentService from '../../services/verification/comment.service.js';
+import commentDto from '../../dtos/verification/comment.dto.js';
+import { request } from 'http';
+
 const getVerificationComments = () => {
   /**
 #swagger.summary = '특정 인증 댓글 조회 API';
@@ -118,7 +123,7 @@ const getVerificationComments = () => {
 };
  */
 };
-const postVerificationComment = () => {
+const postVerificationComment = async (req, res, next) => {
   /**
   #swagger.summary = '챌린지 인증 댓글 작성 API';
   #swagger.description = '특정 챌린지 인증에 댓글을 작성하는 API입니다.';
@@ -253,6 +258,15 @@ const postVerificationComment = () => {
     }
   };
    */
+  try {
+    const user_id = req.user.id;
+    const verification_id = Number(req.params.verificationId);
+    const request_data = commentDto.commentVerificationControllerToService(user_id, verification_id, req.body);
+    const new_comment = await commentService.postVerificationComment(request_data);
+    return res.status(StatusCodes.OK).json(new_comment);
+  } catch (error) {
+    next(error);
+  }
 };
 const updateVerificationComment = () => {
   /**

--- a/src/controllers/verification/comment.controller.js
+++ b/src/controllers/verification/comment.controller.js
@@ -140,12 +140,6 @@ const postVerificationComment = async (req, res, next) => {
     schema: { type: 'string', example: 'application/json' },
     description: '요청 본문의 콘텐츠 타입'
   };
-  #swagger.parameters['challengeId'] = {
-    in: 'path',
-    required: true,
-    schema: { type: 'string', example: '123' },
-    description: '챌린지 ID'
-  };
   #swagger.parameters['verificationId'] = {
     in: 'path',
     required: true,
@@ -161,10 +155,10 @@ const postVerificationComment = async (req, res, next) => {
           type: 'object',
           properties: {
             content: { type: 'string', example: '이 인증 정말 좋네요!', description: '댓글 내용' },
-            userId: { type: 'string', example: 'user56789', description: '댓글 작성자 ID' },
-            username: { type: 'string', example: '작성자 닉네임', description: '댓글 작성자 닉네임' }
+            parentId: { type: 'integer', example: 1, description: '상위 댓글 ID' },
+            anonymous: { type: 'boolean', example: false, description: '익명 여부' }
           },
-          required: ['content', 'userId', 'username']
+          required: ['content', 'parentId', 'anonymous']
         },
       }
     }
@@ -182,11 +176,11 @@ const postVerificationComment = async (req, res, next) => {
               type: 'object',
               properties: {
                 commentId: { type: 'string', example: 'comment12345' },
+                userId: { type: 'integer', example: '1' },
+                verificationId: { type: 'integer', example: '1' },
+                parentId: { type: 'integer', example: '1' },
                 content: { type: 'string', example: '이 인증 정말 좋네요!' },
-                userId: { type: 'string', example: 'user56789' },
-                username: { type: 'string', example: '작성자 닉네임' },
                 createdAt: { type: 'string', format: 'date-time', example: '2025-01-08T12:34:56Z' },
-                message: { type: 'string', example: '댓글이 성공적으로 작성되었습니다.' }
               }
             }
           }

--- a/src/dtos/verification/comment.dto.js
+++ b/src/dtos/verification/comment.dto.js
@@ -10,7 +10,7 @@ const commentVerificationControllerToService = (user_id, verification_id, body) 
   const data = {
     user_id: user_id,
     verification_id: verification_id,
-    parent_id: body.parent_id ?? null,
+    parent_id: body.parentId ?? null,
     anonymous: body.annonymous ?? false,
     content: body.content,
   };

--- a/src/dtos/verification/comment.dto.js
+++ b/src/dtos/verification/comment.dto.js
@@ -1,0 +1,35 @@
+import commentError from '../../errors/verification/comment.error.js';
+
+const commentVerificationControllerToService = (user_id, verification_id, body) => {
+  if (!body.content) {
+    throw new commentError.CommentContentEmtpyError('댓글 내용이 비어있습니다.');
+  }
+  if (!verification_id) {
+    throw new commentError.CommentTypeError('인증 아이디가 누락되었습니다.');
+  }
+  const data = {
+    user_id: user_id,
+    verification_id: verification_id,
+    parent_id: body.parent_id ?? null,
+    anonymous: body.annonymous ?? false,
+    content: body.content,
+  };
+  return data;
+};
+
+const commentVerificationServiceToController = new_comment => {
+  const response_data = {
+    commentId: new_comment[0].id,
+    userId: new_comment[0].user_id,
+    verificationId: new_comment[0].verification_id,
+    parentId: new_comment[0].parent_id,
+    createdAt: new_comment[0].created_at,
+    content: new_comment[0].content,
+  };
+  return response_data;
+};
+
+export default {
+  commentVerificationControllerToService,
+  commentVerificationServiceToController,
+};

--- a/src/errors/verification/comment.error.js
+++ b/src/errors/verification/comment.error.js
@@ -1,5 +1,5 @@
-export class DataBaseError extends Error {
-  errorCode = 'D001';
+export class CommentContentEmtpyError extends Error {
+  errorCode = 'C001';
   constructor(reason, data) {
     super(reason);
     this.reason = reason;
@@ -8,8 +8,8 @@ export class DataBaseError extends Error {
   }
 }
 
-export class DataBaseNotExistError extends Error {
-  errorCode = 'D002';
+export class CommentTypeError extends Error {
+  errorCode = 'C002';
   constructor(reason, data) {
     super(reason);
     this.reason = reason;
@@ -19,6 +19,6 @@ export class DataBaseNotExistError extends Error {
 }
 
 export default {
-  DataBaseError,
-  DataBaseNotExistError,
+  CommentContentEmtpyError,
+  CommentTypeError,
 };

--- a/src/middlewares/auth.middleware.js
+++ b/src/middlewares/auth.middleware.js
@@ -7,7 +7,7 @@ export const authMiddleware = async (req, res, next) => {
   const auth_header = req.headers['authorization'];
   const token = auth_header && auth_header.split(' ')[1];
   if (!token) {
-    throw new authError.AccessTokenError('Access token required');
+    next(new authError.AccessTokenError('Access token required'));
   }
 
   try {

--- a/src/repositories/verification/comment.repository.js
+++ b/src/repositories/verification/comment.repository.js
@@ -1,0 +1,25 @@
+import { prisma } from '../../db.config.js';
+import databaseError from '../../errors/database.error.js';
+
+const postVerificationComment = async request_data => {
+  try {
+    return await prisma.$transaction([
+      prisma.comment.create({
+        data: request_data,
+      }),
+      prisma.verification.update({
+        where: { id: request_data.verification_id },
+        data: { commentsCount: { increment: 1 } },
+      }),
+    ]);
+  } catch (error) {
+    if (error.code === 'P2025') {
+      throw new databaseError.DataBaseNotExistError('해당 인증이 존재하지 않습니다.');
+    }
+    throw new databaseError.DataBaseError('Database error occurred while creating comment');
+  }
+};
+
+export default {
+  postVerificationComment,
+};

--- a/src/routes/verification.routes.js
+++ b/src/routes/verification.routes.js
@@ -27,9 +27,9 @@ router.post('/:verificationId/like', authMiddleware, likeController.likeSpecific
 router.delete('/:verificationId/unlike', authMiddleware, likeController.unlikeSpecificVerification);
 
 // Comment
-router.get('/:challengeId/verification/:verificationId/comment', commentController.getVerificationComments);
-router.post('/:challengeId/verification/:verificationId/comment', commentController.postVerificationComment);
-router.patch('/:challengeId/verification/:verificationId/comment', commentController.updateVerificationComment);
+router.get('/:verificationId/comment', commentController.getVerificationComments);
+router.post('/:verificationId/comment', authMiddleware, commentController.postVerificationComment);
+router.patch('/:verificationId/comment', commentController.updateVerificationComment);
 
 // Scrap
 router.post('/:verificationId/scrap', authMiddleware, scrapController.scrapVerification);

--- a/src/services/verification/comment.service.js
+++ b/src/services/verification/comment.service.js
@@ -1,0 +1,11 @@
+import commentRepository from '../../repositories/verification/comment.repository.js';
+import commentDto from '../../dtos/verification/comment.dto.js';
+const postVerificationComment = async request_data => {
+  const new_comment = await commentRepository.postVerificationComment(request_data);
+  const new_comment_response = commentDto.commentVerificationServiceToController(new_comment);
+  return new_comment_response;
+};
+
+export default {
+  postVerificationComment,
+};


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- 인증글에 댓글 다는 API를 구현했습니다.

## 🔍 작업 상세 (Implementation Details)
- End-point : `/api/v1/verification/:verificationId/comment`
- Method : `POST`
- request 예시
```json
{
  "content": "이 인증 정말 좋네요!",
  "parentId": 1,
  "anonymous": false
}
```
- response 예시
```json
{
    "commentId": 14,
    "userId": 1,
    "verificationId": 1,
    "parentId": 1,
    "createdAt": "2025-01-31T08:50:14.563Z",
    "content": "이 인증 정말 좋네요!"
}
```
