### PR TITLE
Feat/#86 patch verification comment api

### DIFF
--- a/src/controllers/verification/comment.controller.js
+++ b/src/controllers/verification/comment.controller.js
@@ -360,17 +360,11 @@ const updateVerificationComment = async (req, res, next) => {
     schema: { type: 'string', example: 'application/json' },
     description: '요청 본문의 콘텐츠 타입'
   };
-  #swagger.parameters['challengeId'] = {
-    in: 'path',
-    required: true,
-    schema: { type: 'string', example: '101' },
-    description: '챌린지 ID'
-  };
-  #swagger.parameters['verificationId'] = {
+  #swagger.parameters['commentId'] = {
     in: 'path',
     required: true,
     schema: { type: 'string', example: '456' },
-    description: '인증 ID'
+    description: '댓글 ID'
   };
   #swagger.requestBody = {
     required: true,
@@ -399,13 +393,13 @@ const updateVerificationComment = async (req, res, next) => {
             data: {
               type: 'object',
               properties: {
-                commentId: { type: 'string', example: 'comment12345' },
+                id: { type: 'integer', example: 1 },
+                userId: { type: 'integer', example: 23 },
                 content: { type: 'string', example: '이 인증은 정말 멋집니다!' },
-                userId: { type: 'string', example: 'user56789' },
-                username: { type: 'string', example: '작성자 닉네임' },
+                nickname: { type: 'string', example: '작성자 닉네임' },
                 createdAt: { type: 'string', format: 'date-time', example: '2025-01-08T12:34:56Z' },
                 updatedAt: { type: 'string', format: 'date-time', example: '2025-01-08T13:00:00Z' },
-                message: { type: 'string', example: '댓글이 성공적으로 수정되었습니다.' }
+                anonymous: { type: 'boolean', example: false }
               }
             }
           }
@@ -479,7 +473,7 @@ const updateVerificationComment = async (req, res, next) => {
    */
   try {
     const user_id = req.user.id;
-    const comment_id = Number(req.body.commentId);
+    const comment_id = Number(req.params.commentId);
     const content = req.body.content;
     const new_comment = await commentService.updateVerificationComment(user_id, comment_id, content);
     return res.status(StatusCodes.OK).json(new_comment);

--- a/src/controllers/verification/comment.controller.js
+++ b/src/controllers/verification/comment.controller.js
@@ -1,7 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 import commentService from '../../services/verification/comment.service.js';
 import commentDto from '../../dtos/verification/comment.dto.js';
-import { request } from 'http';
 
 const getVerificationComments = () => {
   /**
@@ -262,7 +261,7 @@ const postVerificationComment = async (req, res, next) => {
     next(error);
   }
 };
-const updateVerificationComment = () => {
+const updateVerificationComment = async (req, res, next) => {
   /**
   #swagger.summary = '특정 인증 댓글 수정 API';
   #swagger.description = '특정 인증에 작성된 댓글을 수정하는 API입니다.';
@@ -396,6 +395,15 @@ const updateVerificationComment = () => {
     }
   };
    */
+  try {
+    const user_id = req.user.id;
+    const comment_id = Number(req.body.commentId);
+    const content = req.body.content;
+    const new_comment = await commentService.updateVerificationComment(user_id, comment_id, content);
+    return res.status(StatusCodes.OK).json(new_comment);
+  } catch (error) {
+    next(error);
+  }
 };
 
 export default {

--- a/src/errors/verification/comment.error.js
+++ b/src/errors/verification/comment.error.js
@@ -18,7 +18,51 @@ export class CommentTypeError extends Error {
   }
 }
 
+export class CommentIdError extends Error {
+  errorCode = 'C003';
+  constructor(reason, data) {
+    super(reason);
+    this.reason = reason;
+    this.statuscode = 400;
+    this.data = data;
+  }
+}
+
+export class CommentContentEmptyError extends Error {
+  errorCode = 'C004';
+  constructor(reason, data) {
+    super(reason);
+    this.reason = reason;
+    this.statuscode = 400;
+    this.data = data;
+  }
+}
+
+export class CommentUpdatePermissionDeniedError extends Error {
+  errorCode = 'C005';
+  constructor(reason, data) {
+    super(reason);
+    this.reason = reason;
+    this.statuscode = 403;
+    this.data = data;
+  }
+}
+
+export class CommentNotExistsError extends Error {
+  errorCode = 'C006';
+  constructor(reason, data) {
+    super(reason);
+    this.reason = reason;
+    this.statuscode = 403;
+    this.data = data;
+  }
+}
+
 export default {
   CommentContentEmtpyError,
   CommentTypeError,
+  CommentIdError,
+  CommentContentEmptyError,
+  CommentUpdatePermissionDeniedError,
+  CommentNotExistsError,
 };

--- a/src/repositories/verification/comment.repository.js
+++ b/src/repositories/verification/comment.repository.js
@@ -1,5 +1,6 @@
 import { prisma } from '../../db.config.js';
 import databaseError from '../../errors/database.error.js';
+import commentError from '../../errors/verification/comment.error.js';
 
 const postVerificationComment = async request_data => {
   try {
@@ -20,6 +21,59 @@ const postVerificationComment = async request_data => {
   }
 };
 
+const updateVerificationComment = async (comment_id, content) => {
+  try {
+    const updatedComment = await prisma.comment.update({
+      where: { id: comment_id },
+      data: { content: content },
+    });
+    return updatedComment;
+  } catch (error) {
+    throw new databaseError.DataBaseError('Failed to update comment');
+  }
+};
+
+const getCommentById = async comment_id => {
+  try {
+    const comment = await prisma.comment.findUnique({
+      where: { id: comment_id },
+      select: {
+        id: true,
+        user_id: true,
+        content: true,
+        parent_id: true,
+        created_at: true,
+        updated_at: true,
+        anonymous: true,
+        user: {
+          select: {
+            nickname: true,
+          },
+        },
+      },
+    });
+
+    if (!comment) {
+      throw new commentError.CommentNotExistsError('Comment not found');
+    }
+
+    return {
+      id: comment.id,
+      user_id: comment.user_id,
+      nickname: comment.user.nickname,
+      content: comment.content,
+      parent_id: comment.parent_id,
+      created_at: comment.created_at,
+      updated_at: comment.updated_at,
+      anonymous: comment.anonymous,
+    };
+  } catch (error) {
+    throw new databaseError.DataBaseError('Failed to fetch comment');
+  }
+};
+
 export default {
   postVerificationComment,
+  updateVerificationComment,
+  getCommentById,
 };

--- a/src/repositories/verification/comment.repository.js
+++ b/src/repositories/verification/comment.repository.js
@@ -80,11 +80,19 @@ const postVerificationComment = async request_data => {
 
 const updateVerificationComment = async (comment_id, content) => {
   try {
-    const updatedComment = await prisma.comment.update({
+    const updated_comment = await prisma.comment.update({
       where: { id: comment_id },
       data: { content: content },
     });
-    return updatedComment;
+    return {
+      id: updated_comment.id,
+      user_id: updated_comment.user_id,
+      content: updated_comment.content,
+      parent_id: updated_comment.parent_id,
+      created_at: updated_comment.created_at,
+      updated_at: updated_comment.updated_at,
+      anonymous: updated_comment.anonymous,
+    };
   } catch (error) {
     throw new databaseError.DataBaseError('Failed to update comment');
   }

--- a/src/routes/verification.routes.js
+++ b/src/routes/verification.routes.js
@@ -29,7 +29,7 @@ router.delete('/:verificationId/unlike', authMiddleware, likeController.unlikeSp
 // Comment
 router.get('/:verificationId/comment', commentController.getVerificationComments);
 router.post('/:verificationId/comment', authMiddleware, commentController.postVerificationComment);
-router.patch('/:verificationId/comment', commentController.updateVerificationComment);
+router.patch('/comment/:commentId', authMiddleware, commentController.updateVerificationComment);
 
 // Scrap
 router.post('/:verificationId/scrap', authMiddleware, scrapController.scrapVerification);

--- a/src/services/verification/comment.service.js
+++ b/src/services/verification/comment.service.js
@@ -1,11 +1,34 @@
 import commentRepository from '../../repositories/verification/comment.repository.js';
 import commentDto from '../../dtos/verification/comment.dto.js';
+import commentError from '../../errors/verification/comment.error.js';
+
+const getVerificationComment = async verification_id => {
+  const comments = await commentRepository.getVerificationComment(verification_id);
+  return comments;
+};
+
 const postVerificationComment = async request_data => {
   const new_comment = await commentRepository.postVerificationComment(request_data);
   const new_comment_response = commentDto.commentVerificationServiceToController(new_comment);
   return new_comment_response;
 };
 
+const updateVerificationComment = async (user_id, comment_id, content) => {
+  if (!comment_id) {
+    throw new commentError.CommentIdError('comment_id is required');
+  }
+  if (!content || content.trim() === '') {
+    throw new commentError.CommentContentEmptyError('Content cannot be empty');
+  }
+  const comment = await commentRepository.getCommentById(comment_id);
+  if (comment.user_id != user_id) {
+    throw new commentError.CommentUpdatePermissionDeniedError('Cannot update comment : Permission denied');
+  }
+  const updated_comment = await commentRepository.updateVerificationComment(comment_id, content);
+  return updated_comment;
+};
+
 export default {
   postVerificationComment,
+  updateVerificationComment,
 };

--- a/src/services/verification/comment.service.js
+++ b/src/services/verification/comment.service.js
@@ -25,7 +25,7 @@ const updateVerificationComment = async (user_id, comment_id, content) => {
     throw new commentError.CommentUpdatePermissionDeniedError('Cannot update comment : Permission denied');
   }
   const updated_comment = await commentRepository.updateVerificationComment(comment_id, content);
-  return updated_comment;
+  return { ...updated_comment, nickname: comment.nickname };
 };
 
 export default {


### PR DESCRIPTION
## 🚀 기능 설명 (Feature Description)
- 인증에 달린 댓글을 수정하는 API를 구현합니다.

## 🔍 구현 상세 (Implementation Details)
- End-point : `/api/v1/verification/{verificationId}/comment`
- Method : `PATCH`
- Request 예시
```json
{
	"Authorization": "Bearer {token}"
}
{
    "commentId": 1,
    "content" : "수정된 내용"
}
```
- Response 예시
```json
{
  "resultType": "SUCCESS",
  "error": null,
  "success": {
    "comments": [
     {
          "commentId": 14,
          "userId": 1,
          "verificationId": 1,
          "parentId": 1,
          "createdAt": "2025-01-31T08:50:14.563Z",
          "content": "이 인증 정말 좋네요!"
     },