### PR TITLE
Feat/#91 challenge text verification

### DIFF
--- a/src/controllers/verification/verification.controller.js
+++ b/src/controllers/verification/verification.controller.js
@@ -523,7 +523,7 @@ const textVerification = async (req, res, next) => {
             textUrl: { type: 'string', example: 'https://notionverification.com', description: '인증 글의 외부 링크 URL' },
             question: { type: 'boolean', example: false, description: '질문 여부' }
           },
-          required: ['title', 'content', 'textUrl', 'question']
+          required: ['title', 'content', 'question']
         },
       }
     }
@@ -544,33 +544,9 @@ const textVerification = async (req, res, next) => {
                 verifications: {
                   type: 'object',
                   properties: {
-                    UserInfo: {
-                      type: 'object',
-                      properties: {
-                        id: { type: 'string', example: '2' },
-                        name: { type: 'string', example: '유엠씨' },
-                        profilePhoto: { type: 'string', example: 'https://profile.com' }
-                      }
-                    },
-                    challengeInfo: {
-                      type: 'object',
-                      properties: {
-                        id: { type: 'string', example: '2' },
-                        name: { type: 'string', example: '책 읽는 챌린지' },
-                        challengeType: { type: 'string', example: 'basic' }
-                      }
-                    },
-                    verification: {
-                      type: 'object',
-                      properties: {
-                        id: { type: 'string', example: '2' },
-                        title: { type: 'string', example: '챌린지 글로 인증하기' },
-                        content: { type: 'string', example: '인증 글입니다!' },
-                        textUrl: { type: 'string', example: 'https://notionverification.com' },
-                        question: { type: 'boolean', example: false },
-                        created_at: { type: 'string', format: 'date-time', example: '2025-01-07' }
-                      }
-                    }
+                    verificationId: { type: 'integer', example: 2 },
+                    VerificationType: { type: 'string', example: 'text' },
+                    title: { type: 'string', example: '1일차 챌린지 인증' }
                   }
                 }
               }

--- a/src/controllers/verification/verification.controller.js
+++ b/src/controllers/verification/verification.controller.js
@@ -499,7 +499,7 @@ const cameraVerification = async (req, res, next) => {
   }
 };
 
-const textVerification = () => {
+const textVerification = async (req, res, next) => {
   /**
   #swagger.summary = '챌린지 글 인증 등록 API';
   #swagger.description = '사용자가 챌린지 글로 인증을 등록하는 API입니다. 제목, 내용, 링크, 질문 여부 등을 포함합니다.';
@@ -644,6 +644,15 @@ const textVerification = () => {
     }
   };
    */
+  try {
+    const user_id = req.user.id;
+    const challenge_id = parseInt(req.params.challengeId, 10);
+    const completed_challenge = await verificationService.verifyWithText(user_id, challenge_id, req.body);
+
+    return res.status(StatusCodes.OK).json(completed_challenge);
+  } catch (error) {
+    next(error);
+  }
 };
 const getTemporaryVerification = () => {
   /**

--- a/src/dtos/verification/verification.dto.js
+++ b/src/dtos/verification/verification.dto.js
@@ -11,10 +11,21 @@ const cameraVerificationServiceToController = data => {
   return response_data;
 };
 
+const textVerificationServiceToController = data => {
+  const response_data = {
+    message: '챌린지 인증이 완료되었습니다.',
+    verification: {
+      verificationId: data.id,
+      verificationType: data.verificationType,
+      title: data.title,
+    },
+  };
+  return response_data;
+};
+
 const cameraVerificationServiceToRepositoryDto = (user_id, user_challenge_id, body) => {
   if (!body?.photoUrl) throw new Error('photoUrl is required in body');
   if (!body?.title) throw new Error('title is required in body');
-  if (!body?.photoUrl) throw new Error('title is required in body');
   return {
     user_id: user_id,
     userChallenge_id: user_challenge_id,
@@ -29,7 +40,26 @@ const cameraVerificationServiceToRepositoryDto = (user_id, user_challenge_id, bo
   };
 };
 
+const textVerificationServiceToRepositoryDto = (user_id, user_challenge_id, body) => {
+  console.log(body);
+  if (!body?.title) throw new Error('title is required in body');
+  return {
+    user_id: user_id,
+    userChallenge_id: user_challenge_id,
+    title: body.title,
+    content: body.content ?? null,
+    textUrl: body.textUrl ?? null,
+    question: body.question ?? false,
+    photoUrl: null,
+    verificationType: 'text',
+    adoptionComplete: false,
+    verificationStatus: 'certified',
+  };
+};
+
 export default {
   cameraVerificationServiceToController,
+  textVerificationServiceToController,
   cameraVerificationServiceToRepositoryDto,
+  textVerificationServiceToRepositoryDto,
 };

--- a/src/dtos/verification/verification.dto.js
+++ b/src/dtos/verification/verification.dto.js
@@ -41,7 +41,6 @@ const cameraVerificationServiceToRepositoryDto = (user_id, user_challenge_id, bo
 };
 
 const textVerificationServiceToRepositoryDto = (user_id, user_challenge_id, body) => {
-  console.log(body);
   if (!body?.title) throw new Error('title is required in body');
   return {
     user_id: user_id,

--- a/src/repositories/verification/verification.repository.js
+++ b/src/repositories/verification/verification.repository.js
@@ -8,8 +8,22 @@ const verifyWithCamera = async dto => {
     });
     return camera_verification;
   } catch (error) {
-    throw new databaseError.DataBaseError('Error on creating email verification');
+    throw new databaseError.DataBaseError('Error on creating camera verification');
   }
 };
 
-export default { verifyWithCamera };
+const verifyWithText = async dto => {
+  try {
+    const text_verification = await prisma.verification.create({
+      data: dto,
+    });
+    return text_verification;
+  } catch (error) {
+    throw new databaseError.DataBaseError('Error on creating text verification');
+  }
+};
+
+export default {
+  verifyWithCamera,
+  verifyWithText,
+};

--- a/src/routes/verification.routes.js
+++ b/src/routes/verification.routes.js
@@ -12,7 +12,7 @@ router.get('/:challengeId/verification-status', veriificationController.getChall
 router.get('/:challengeId/verification/weekly', veriificationController.getWeeklyVerification);
 router.get('/:challengeId/verifications/:verificationId', veriificationController.getSpecificVerification);
 router.post('/:challengeId/verification/camera', authMiddleware, veriificationController.cameraVerification);
-router.post('/:challengeId/verification/text', veriificationController.textVerification);
+router.post('/:challengeId/verification/text', authMiddleware, veriificationController.textVerification);
 router.get(
   '/:challengeId/verification/text/:temporaryVerificationId',
   veriificationController.getTemporaryVerification,

--- a/src/services/verification/verification.service.js
+++ b/src/services/verification/verification.service.js
@@ -4,6 +4,7 @@ import listError from '../../errors/challenge/list.error.js';
 import verificationError from '../../errors/verification/verification.error.js';
 import participationRepository from '../../repositories/challenge/participation.repository.js';
 import verificationDto from '../../dtos/verification/verification.dto.js';
+
 const verifyWithCamera = async (user_id, challenge_id, body) => {
   const challenge = await listRepository.getChallengeDetailById(challenge_id);
   if (!challenge) {
@@ -22,6 +23,25 @@ const verifyWithCamera = async (user_id, challenge_id, body) => {
   return camera_verification_response;
 };
 
+const verifyWithText = async (user_id, challenge_id, body) => {
+  const challenge = await listRepository.getChallengeDetailById(challenge_id);
+  if (!challenge) {
+    throw new listError.ChallengeIdNotExistsError('해당 챌린지를 찾을 수 없습니다.');
+  }
+  const user_challenge = await participationRepository.getUserChallengeById(user_id, challenge_id);
+  if (!user_challenge) {
+    throw new listError.ChallengeIdNotExistsError('해당 챌린지를 찾을 수 없습니다.');
+  }
+  const data = verificationDto.textVerificationServiceToRepositoryDto(user_id, user_challenge.id, body);
+  if (challenge.verificationType != 'text') {
+    throw new verificationError.VerificationTypeDoesntMatchError('챌린지가 텍스트 인증 타입이 아닙니다.');
+  }
+  const text_verification = await verificationRepository.verifyWithText(data);
+  const text_verification_response = verificationDto.textVerificationServiceToController(text_verification);
+  return text_verification_response;
+};
+
 export default {
   verifyWithCamera,
+  verifyWithText,
 };


### PR DESCRIPTION
## 🚀 기능 설명 (Feature Description)
- 챌린지 텍스트 인증 기능을 구현했습니다..

## 🔍 구현 상세 (Implementation Details)
- 메소드 : `api/v1/verification/{challengeId}/verification/text`
- API Endpoint: `POST`
- request
```json
POST /api/v1/challenge/{challengeId}/verification/camera
{
	"Authorization": "Bearer abcdef123456",
  "Content-Type": "multipart/form-data"
}
{
  "title": "1일차 챌린지 인증",
  "content": "This is a sample verification content.",
  "textUrl": "https://example.com/text",
  "question": true
}
```
- response
```json
{
  "resultType": "SUCCESS",
  "error": null,
  "success": {
    "message": "챌린지 인증이 완료되었습니다.",
    "verification": {
        "verificationId": 6,
        "verificationType": "text",
        "title": "1일차 챌린지 인증"
    }
}
}

```

## 📝 추가 정보 (Additional Information)
카메라 인증과 글 인증은 다음 내용에서 추가적인 수정이 필요합니다.
- 엔드포인트 재설정
- 하루에 중복 인증 방지
- 인증시 DB에 하루동안 저장 후 삭제
