### PR TITLE
Fix: get-daily-hot-challenge-Add freqencyValue and duration response

### DIFF
--- a/src/routes/challenge.routes.js
+++ b/src/routes/challenge.routes.js
@@ -21,9 +21,9 @@ router.get('/:challengeId/verification/my', authMiddleware, participationControl
 router.post('/:challengeId/join', authMiddleware, participationController.joinChallenge);
 router.post('/:challengeId/like', authMiddleware, participationController.likeChallenge);
 router.delete('/:challengeId/unlike', authMiddleware, participationController.unlikeChallenge);
-// router.post('/:challengeId/participation', participationController.participateInChallenge);
-// router.get('/:challengeId/challengerslist', participationController.getChallengeParticipantsList);
-// router.get('/:challengeId/challengerslist/kick', participationController.kickChallengeParticipant);
+router.post('/:challengeId/participation', participationController.participateInChallenge);
+router.get('/:challengeId/challengerslist', participationController.getChallengeParticipantsList);
+router.get('/:challengeId/challengerslist/kick', participationController.kickChallengeParticipant);
 router.get('/:challengeId/calendar', participationController.getChallengeCalendar);
 
 export default router;

--- a/src/routes/challenge.routes.js
+++ b/src/routes/challenge.routes.js
@@ -21,9 +21,9 @@ router.get('/:challengeId/verification/my', authMiddleware, participationControl
 router.post('/:challengeId/join', authMiddleware, participationController.joinChallenge);
 router.post('/:challengeId/like', authMiddleware, participationController.likeChallenge);
 router.delete('/:challengeId/unlike', authMiddleware, participationController.unlikeChallenge);
-router.post('/:challengeId/participation', participationController.participateInChallenge);
-router.get('/:challengeId/challengerslist', participationController.getChallengeParticipantsList);
-router.get('/:challengeId/challengerslist/kick', participationController.kickChallengeParticipant);
+// router.post('/:challengeId/participation', participationController.participateInChallenge);
+// router.get('/:challengeId/challengerslist', participationController.getChallengeParticipantsList);
+// router.get('/:challengeId/challengerslist/kick', participationController.kickChallengeParticipant);
 router.get('/:challengeId/calendar', participationController.getChallengeCalendar);
 
 export default router;

--- a/src/services/challenge/category.service.js
+++ b/src/services/challenge/category.service.js
@@ -38,6 +38,7 @@ const getDailyHotChallenge = async () => {
                 },
               },
             },
+            frequencies: true, //인증 빈도 데이터 포함
           },
         });
         // 좋아요 개수 기준으로 정렬
@@ -57,6 +58,45 @@ const getDailyHotChallenge = async () => {
             where: { category: category },
           });
           top_challenge = fallback_challenge || { id: null, name: `기본 ${category} 챌린지`, category };
+        }
+        if (top_challenge) {
+          // 🔥 챌린지 인증 빈도 가져오기
+          let certification_frequency = null;
+          if (top_challenge.type === 'basic') {
+            certification_frequency =
+              top_challenge.frequencies.length > 0 ? top_challenge.frequencies[0].frequencyValue : null;
+          } else if (top_challenge.type === 'study') {
+            certification_frequency =
+              top_challenge.frequencies.length > 0
+                ? Object.entries(top_challenge.frequencies[0])
+                    .filter(
+                      ([key, value]) =>
+                        ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'].includes(key) &&
+                        value === true,
+                    )
+                    .map(([key]) => key)
+                : [];
+          }
+          // 🔥 챌린지 기간 가져오기
+          let challenge_duration = null;
+          if (top_challenge.type === 'basic') {
+            challenge_duration = top_challenge.duration;
+          } else if (top_challenge.type === 'study') {
+            if (top_challenge.joinDate && top_challenge.endDate) {
+              const diffDays = Math.ceil((top_challenge.endDate - top_challenge.joinDate) / (1000 * 60 * 60 * 24));
+              if (diffDays <= 7) challenge_duration = '1주일';
+              else if (diffDays <= 14) challenge_duration = '2주일';
+              else if (diffDays <= 21) challenge_duration = '3주일';
+              else if (diffDays <= 31) challenge_duration = '1개월';
+              else if (diffDays <= 91) challenge_duration = '3개월';
+              else if (diffDays <= 181) challenge_duration = '6개월';
+              else challenge_duration = '1년';
+            }
+          }
+
+          // 챌린지에 인증 빈도와 기간 추가
+          top_challenge.certification_frequency = certification_frequency;
+          top_challenge.challenge_duration = challenge_duration;
         }
         return top_challenge;
       }),


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- frequencyValue와 duration이 같이 반환되도록 구현했습니다.

## 🔍 작업 상세 (Implementation Details)
- 베이직 챌린지의 경우는 duration과 frequencyValue를 반환합니다.
- 스터디 챌린지의 경우는 joinDate와 endDate를 계산해서
challenge_duration으로, 그리고 frequencyValue 역할을 하는 certification_frequency를 반환하도록 합니다.

## 🖼️ 이미지 첨부 (Images)
![image](https://github.com/user-attachments/assets/b8c52c2c-7086-4cc2-b634-2b04c015c567)

## 📝 추가 정보 (Additional Information)
- 좋아요 시간 계산하는 이슈를 여러가지 방면으로 지웠다가 새로 진행하면서 기존에 구현해두었던 frequencyValue랑 duration 반환하는 코드가 삭제 된 상황이었습니다. ㅠㅠ 다음부터 주의해서 올리도록 하겠습니다ㅠㅠ