### PR TITLE
[bug] 카카오 로그인 시 id가 전달되지 않는 문제 해결

### DIFF
--- a/src/repositories/users.repository.js
+++ b/src/repositories/users.repository.js
@@ -7,7 +7,7 @@ import databaseError from '../errors/database.error.js';
 const putUserInterestCategory = async (user_id, update_data) => {
   try {
     // 사용자의 관심 카테고리 저장
-    const updated_user = await prisma.userCategoryType.upsert({
+    await prisma.userCategoryType.upsert({
       where: { user_id },
       update: { category: update_data.category },
       create: { user_id, category: update_data.category },

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -162,12 +162,12 @@ const signInKakao = async kakao_token => {
     if (!user) {
       user = await authRepository.signUpKakao(email);
     }
-
+    const id = user.id;
     // 3. JWT 발급
-    const access_token = jwt.sign({ kakao_id, email }, process.env.ACCESS_TOKEN_SECRET);
-    const refresh_token = jwt.sign({ kakao_id, email }, process.env.REFRESH_TOKEN_SECRET);
+    const access_token = jwt.sign({ kakao_id, email, id }, process.env.ACCESS_TOKEN_SECRET);
+    const refresh_token = jwt.sign({ kakao_id, email, id }, process.env.REFRESH_TOKEN_SECRET);
 
-    return { access_token, refresh_token };
+    return { id, access_token, refresh_token };
   } catch (error) {
     throw new authError.KakaoLoginError('카카오 로그인 실패');
   }

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -167,9 +167,7 @@ const signInKakao = async kakao_token => {
     const access_token = jwt.sign({ kakao_id, email, id }, process.env.ACCESS_TOKEN_SECRET);
     const refresh_token = jwt.sign({ kakao_id, email, id }, process.env.REFRESH_TOKEN_SECRET);
 
-    const user_id = user.id;
-
-    return { userId: user_id, accessToken: access_token, refreshToken: refresh_token };
+    return { userId: id, accessToken: access_token, refreshToken: refresh_token };
   } catch (error) {
     throw new authError.KakaoLoginError('카카오 로그인 실패');
   }


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- 전달되는 객체에 user_id가 포함되어 있지 않아서 id를 이용한 기능 작동 불가 상황
- 카카오 로그인 token 발행 시 user_id까지 포함하여 id 전달 가능 상태로 변경

## 📝 추가 정보 (Additional Information)
- dev 머지 전으로 머지 후 충돌 해결 필요
