### PR TITLE
Feat: check password api

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -117,6 +117,17 @@ const changePassword = async (req, res, next) => {
   }
 };
 
+const checkPassword = async (req, res, next) => {
+  try {
+    const user_id = req.user.id;
+    const password = req.body.password;
+    const response = await authService.checkPassword(user_id, password);
+    return res.success(response, StatusCodes.OK);
+  } catch (error) {
+    return next(error);
+  }
+};
+
 export default {
   emailLogin,
   kakaoLogin,
@@ -130,4 +141,5 @@ export default {
   checkEmailVerificationCode,
   checkNickname,
   changePassword,
+  checkPassword,
 };

--- a/src/docs/swagger/auth.json
+++ b/src/docs/swagger/auth.json
@@ -601,6 +601,90 @@
           }
         }
       }
+    },
+    "/api/v1/auth/password/check": {
+      "post": {
+        "summary": "비밀번호 인증 API",
+        "description": "사용자가 입력한 비밀번호가 기존 비밀번호와 일치하는지 확인하는 API입니다. 성공 시, 비밀번호 인증이 완료되었다는 메시지를 반환합니다.",
+        "tags": ["Auth"],
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "description": "비밀번호 인증 요청 정보",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "password": {
+                    "type": "string",
+                    "example": "password123"
+                  }
+                },
+                "required": ["password"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "비밀번호 인증 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "비밀번호 인증이 완료되었습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "잘못된 요청",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "FAILURE"
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "비밀번호가 일치하지 않습니다."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증 실패 (Unauthorized)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": {
+                      "type": "string",
+                      "example": "FAILURE"
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "인증이 필요합니다."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/routes/auth.routes.js
+++ b/src/routes/auth.routes.js
@@ -17,6 +17,7 @@ router.post('/send-verify-email', authController.sendVerificationCode);
 router.post('/check-email-verification-code', authController.checkEmailVerificationCode);
 router.post('/check-nickname', authController.checkNickname);
 router.patch('/password', authMiddleware, authController.changePassword);
+router.post('/password/check', authMiddleware, authController.checkPassword);
 // Refresh Token Route
 router.post('/token', authController.refreshToken);
 

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -30,7 +30,7 @@ const login = async (email, password) => {
   }
   const is_password_valid = await bcrypt.compare(password, user.password);
   if (!is_password_valid) {
-    throw new authError.PasswordMismatchError('비밀번호가 일치하지 않습니다.', { password });
+    throw new authError.PasswordMismatchError('비밀번호가 일치하지 않습니다.');
   }
   if (user.isDeleted) {
     throw new authError.UserQuitError('이미 탈퇴한 유저입니다.');
@@ -207,6 +207,18 @@ const changePassword = async (user_id, new_password) => {
   return response;
 };
 
+const checkPassword = async (user_id, password) => {
+  const user = await authRepository.findUserById(user_id);
+  if (!user) {
+    throw new authError.UserNotExistError('존재하지 않는 사용자입니다.');
+  }
+  const is_password_valid = await bcrypt.compare(password, user.password);
+  if (!is_password_valid) {
+    throw new authError.PasswordMismatchError('비밀번호가 일치하지 않습니다.');
+  }
+  return { message: '비밀번호 인증이 완료되었습니다.' };
+};
+
 export default {
   generateTokens,
   verifyRefreshToken,
@@ -218,4 +230,5 @@ export default {
   checkNickname,
   resetPasswordByEmail,
   changePassword,
+  checkPassword,
 };


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- **비밀번호 인증 API**: 사용자가 제공한 비밀번호가 데이터베이스에 저장된 비밀번호와 일치하는지 확인하는 API입니다. 인증이 성공하면, 사용자는 비밀번호 인증이 완료되었다는 메시지를 받게 됩니다.

---

## 🔍 작업 상세 (Implementation Details)
- **Bearer 인증**을 이용하여 사용자의 인증을 처리합니다.
- 사용자는 **password**를 요청 본문에 포함하여 전송합니다.
- 서버는 요청된 비밀번호를 데이터베이스에 저장된 비밀번호와 비교하여 인증합니다.
- 인증이 성공하면 `"비밀번호 인증이 완료되었습니다."`라는 메시지를 반환합니다.

**Request Body**:
```json
{
  "password": "password123"
}
```

**Response**:
성공 시:
```json
{
  "message": "비밀번호 인증이 완료되었습니다."
}
```

실패 시:
```json
{
  "resultType": "FAILURE",
  "error": "비밀번호가 일치하지 않습니다."
}
```

---

## 🖼️ 이미지 첨부 (Images)
- 현재는 API 설계나 코드에 관한 이미지가 없습니다.

---

## 📋 관련 자료 (Related Resources)
- [JWT 공식 문서](https://jwt.io/)
- [Node.js Express 인증 미들웨어 예제](https://expressjs.com/en/starter/basic-routing.html)
- [bcrypt 공식 문서](https://www.npmjs.com/package/bcrypt)

---

## 📝 추가 정보 (Additional Information)
- 이 API는 **Bearer Token*인증을 요구하므로 사용자는 유효한 토큰을 헤더에 포함해야 합니다.
- 비밀번호 인증 시, 보안상의 이유로 입력된 비밀번호를 **평문으로 저장하지 않으며**, `bcrypt.compare()`를 통해 비교합니다.
- 인증 실패 시 `401 Unauthorized` 상태 코드와 함께 적절한 오류 메시지를 반환합니다.
- 추가적으로 인증 실패 시, **재시도 제한**이나 **로그인 차단*기능을 고려할 수 있습니다.
