### PR TITLE
[Bug] 최근 획득 배지 user_badge 없을 시 null 반환

### DIFF
--- a/src/services/users.service.js
+++ b/src/services/users.service.js
@@ -99,10 +99,10 @@ const getUserBadgesById = async user_id => {
 
 const getUserLatestBadgeById = async user_id => {
   const badge = await userRepository.findUserLatestBadge(user_id);
-  const response_data = userDto.userLatestBadgeDto(badge);
-  if (!response_data) {
+  if (!badge) {
     return null;
   }
+  const response_data = userDto.userLatestBadgeDto(badge);
 
   return response_data;
 };


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- 최근 획득한 배지 api를 불렀을 때 user_badge가 없을 시에 null을 반환하도록 했습니다.
- badge 테이블의 데이터는 항상 존재

![image](https://github.com/user-attachments/assets/0bde8c46-2446-40b9-ae62-80d51e063b9f)
